### PR TITLE
Add: Boreas timeout

### DIFF
--- a/doc/boreas.8.in
+++ b/doc/boreas.8.in
@@ -33,6 +33,10 @@ One or many hosts to exclude form the target list. The list is comma-separated. 
 Ports to check for every target in the target list. The syntax of this option is flexible, it can be a single range ("1-1500"), several ports ("21,23,80"), several ranges of ports ("1-1500,32000-33000").
 
 .TP
+.BI "--timeout"
+Max. wait time for replies. Default 3
+
+.TP
 .BI "--icmp"
 Use ICMP ping for alive detection.
 
@@ -47,7 +51,7 @@ Use TCP-SYN ping for alive detection.
 .TP
 .BI "--arp"
 Use ARP ping for alive detection.
-	
+
 .SH AUTHORS
 
 (C) 2020 Greenbone Networks GmbH.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,9 @@ if (NOT PKG_CONFIG_FOUND)
   message(FATAL_ERROR "pkg-config executable not found. Aborting.")
 endif (NOT PKG_CONFIG_FOUND)
 
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=20.8)
-pkg_check_modules (LIBGVM_BOREAS REQUIRED libgvm_boreas>=20.8)
-pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=20.8)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4)
+pkg_check_modules (LIBGVM_BOREAS REQUIRED libgvm_boreas>=22.4)
+pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.4)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 
 message (STATUS "Looking for pcap...")

--- a/src/boreas.c
+++ b/src/boreas.c
@@ -62,6 +62,7 @@ main (int argc, char *argv[])
   static gboolean tcp_ack = FALSE;
   static gboolean tcp_syn = FALSE;
   static gboolean arp = FALSE;
+  static unsigned int wait_timeout = 3;
 
   GError *error = NULL;
   GOptionContext *option_context;
@@ -85,6 +86,8 @@ main (int argc, char *argv[])
      "TCP-ACK ping. Supports both IPv4 and IPv6.", NULL},
     {"arp", '\0', 0, G_OPTION_ARG_NONE, &arp,
      "ARP ping. Supports both IPv4 and IPv6.", NULL},
+    {"timeout", '\0', 0, G_OPTION_ARG_INT, &wait_timeout,
+     "Wait time for replies.", NULL},
     {NULL, 0, 0, 0, NULL, NULL, NULL}};
 
   option_context = g_option_context_new ("- Boreas");
@@ -184,7 +187,7 @@ main (int argc, char *argv[])
     }
 
   /* Run the cli scan. */
-  err = run_cli (hosts, alive_test, port_list);
+  err = run_cli (hosts, alive_test, port_list, wait_timeout);
   if (err)
     printf ("Could not run the scan. %s. Further information can be found in "
             "the log file located in %s. \n",

--- a/src/boreas.c
+++ b/src/boreas.c
@@ -187,7 +187,7 @@ main (int argc, char *argv[])
     }
 
   /* Run the cli scan. */
-  err = run_cli (hosts, alive_test, port_list, wait_timeout);
+  err = run_cli_extended (hosts, alive_test, port_list, wait_timeout);
   if (err)
     printf ("Could not run the scan. %s. Further information can be found in "
             "the log file located in %s. \n",


### PR DESCRIPTION
**What**:
Add command line option for the test timeout.

Jira: SC-680
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It was hardcoded before. The boreas lib allows now this option
<!-- Why are these changes necessary? -->

**How**:
Run boreas against a dead target with and without the option.
`sudo boreas --target 192.168.158.1`
`sudo boreas --target 192.168.158.1 --timeout 7`

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
