### PR TITLE
run_cli_extended only exits in the gvm lib 22.4.1 an newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+- Update required gvm lib to 22.4.1, because of run_cli_extended
 - Make it more FSH conform and use bin instand of sbin as the target dir [#20](https://github.com/greenbone/boreas/pull/20)
 All notable changes to this project will be documented in this file.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,9 @@ if (NOT PKG_CONFIG_FOUND)
   message(FATAL_ERROR "pkg-config executable not found. Aborting.")
 endif (NOT PKG_CONFIG_FOUND)
 
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4)
-pkg_check_modules (LIBGVM_BOREAS REQUIRED libgvm_boreas>=22.4)
-pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.4)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4.1)
+pkg_check_modules (LIBGVM_BOREAS REQUIRED libgvm_boreas>=22.4.1)
+pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.4.1)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 
 message (STATUS "Looking for pcap...")


### PR DESCRIPTION
**What**:
see https://github.com/greenbone/boreas/issues/36

**Why**:

See header



**Checklist**:

- [ ] Tests
- [ X] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
