### PR TITLE
Fix: Fix prod.Dockerfile build

### DIFF
--- a/.github/install-dependencies.sh
+++ b/.github/install-dependencies.sh
@@ -9,4 +9,5 @@ apt-get update && apt-get install --no-install-recommends --no-install-suggests 
     libglib2.0-dev \
     libgnutls28-dev \
     libpcap-dev \
+    libssh-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**What**:

libssh-dev added to install-dependencies.sh

**Why**:

gvm-libs switched from libssh-gcrypt-dev to libssh-dev and libgrcypt-dev because libssh-gcrypt got deprecated in debian testing channel.
Therefore in a chained workflow from gvm-libs's github action the build of the prod.Dockerfile of boreas was failing.
The reason is simple, gvm-libs now requires libssh-dev.

**How**:

1. Checkout of the main branch of this repository.
2. run 'docker build --file .docker/prod.Dockerfile .'

**Checklist**:

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
