### PR TITLE
˝Change: Update gvm-libs image in prod.Dockerfile and build.Dockerfile

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,6 +1,6 @@
 ARG VERSION=unstable
 
-FROM greenbone/gvm-libs:$VERSION
+FROM registry.community.greenbone.net/community/gvm-libs:${VERSION}
 LABEL deprecated="This image is deprecated and may be removed soon."
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=edge
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/boreas
-FROM greenbone/gvm-libs:$VERSION AS build
+FROM registry.community.greenbone.net/community/gvm-libs:${VERSION} AS build
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,9 +9,9 @@ COPY . /source
 RUN sh /source/.github/install-dependencies.sh
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 
-RUN DESTDIR=/install cmake --build /build -- install 
+RUN DESTDIR=/install cmake --build /build -- install
 
-FROM greenbone/gvm-libs:$VERSION
+FROM registry.community.greenbone.net/community/gvm-libs:${VERSION}
 
 COPY --from=build /install/ /
 


### PR DESCRIPTION
## What

Update gvm-libs image in prod.Dockerfile and build.Dockerfile

## Why

In the next release gvm-libs will be pushed to a new registry, therefore the reference needs to be updated.

## References

https://jira.greenbone.net/browse/DEVOPS-1229

## Checklist

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
